### PR TITLE
Fix Vim error regarding weak constraints

### DIFF
--- a/syntax/gringo.vim
+++ b/syntax/gringo.vim
@@ -79,7 +79,7 @@ syn match   gringoVar      "\<_*[A-Z]['a-zA-Z0-9_]*\>'*"
 syn match   gringoOperator "=\|<\|<=\|>\|>=\|=\|==\|!="
 syn match   gringoNumber   "\<[0123456789]*\>"
 syn match   gringoRule     ":-"
-syn match   gringoRule     ":~"
+syn match   gringoRule     ":\~"
 
 syn sync maxlines=500
 


### PR DESCRIPTION
Fixes #4.

Error: `E874: (NFA) Could not pop the stack!`

Apparently, `~` is a special regex character